### PR TITLE
Enhance MongoFrameworkQueryProvider for multiple pre-stages

### DIFF
--- a/src/MongoFramework/Linq/LinqExtensions.cs
+++ b/src/MongoFramework/Linq/LinqExtensions.cs
@@ -108,7 +108,7 @@ namespace MongoFramework.Linq
 			};
 
 			var originalProvider = dbSet.Provider as IMongoFrameworkQueryProvider<TEntity>;
-			var provider = new MongoFrameworkQueryProvider<TEntity>(originalProvider, stage);
+			var provider = new MongoFrameworkQueryProvider<TEntity>(originalProvider, [stage]);
 			return new MongoFrameworkQueryable<TEntity>(provider);
 		}
 	}


### PR DESCRIPTION
This pull request refactors the `MongoFrameworkQueryProvider` class to enhance flexibility and consistency in handling query stages. The most significant changes include replacing the single `PreStage` property with a collection of `PreStages`, updating constructors to accommodate the new property, and modifying related methods to support the updated design.
